### PR TITLE
Extends default kanban view

### DIFF
--- a/vcls-contact/views/contact_views.xml
+++ b/vcls-contact/views/contact_views.xml
@@ -246,6 +246,21 @@
             </field>
         </record>
 
+        <!-- Add Account Manager in partner kanban view -->
+        <record id="res_partner_kanban_view" model="ir.ui.view">
+            <field name="name">res.partner.kanban.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.res_partner_kanban_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[hasclass('oe_kanban_partner_links')]" position="before">
+                    <div t-if="record.user_id.raw_value">
+                        <span class="fa fa-user-circle" aria-label="Account Manager" title="Account Manager"/>
+                        <field name="user_id"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
         <!-- VCLS Offices KANBAN View -->
         <record id="view_kanban_vcls_office" model="ir.ui.view">
         <field name="name">res.partner.vclsoffice.kanban</field>


### PR DESCRIPTION
Preview :
![image](https://user-images.githubusercontent.com/46442806/57306812-c4041600-70e3-11e9-9245-9ac118b458ec.png)

- Lorsque l'Account Manager n'est pas renseigné, rien n'est affiché sur la kanban view :
![image](https://user-images.githubusercontent.com/46442806/57306928-ef870080-70e3-11e9-958f-f222efde8510.png)
- J'ai étendu la vue kanban par défaut (celle-ci sera affichée pour toutes les vues où aucune kanban view spécifique n'est demandée)