### PR TITLE
Delete overwritten context in inverse for product pricelist in res pa…

### DIFF
--- a/vcls-crm/models/contact.py
+++ b/vcls-crm/models/contact.py
@@ -44,11 +44,30 @@ class ContactExt(models.Model):
             rec.default_currency_id = rec.property_product_pricelist.currency_id
     
     def _set_default_currency(self):
-        self = self.sudo()
         #raise UserError('{}'.format(self.default_currency_id.name))
         for rec in self:
-            pricelist = self.env['product.pricelist'].search([('company_id', '=', False), ('currency_id', '=', rec.default_currency_id.id)], limit=1)
+            pricelist = self.sudo().env['product.pricelist'].search([('company_id', '=', False), ('currency_id', '=', rec.default_currency_id.id)], limit=1)
             if not pricelist:
                 raise UserError(('Please define a company independent pricelist with currency %s') % rec.default_currency_id.name)
-            for company in self.env['res.company'].search([]):
+            for company in self.sudo().env['res.company'].search([]):
                 rec.with_context(force_company=company.id).property_product_pricelist = pricelist
+    
+    # NOT OVERWRITE CONTEXT
+    @api.one
+    def _inverse_product_pricelist(self):
+        pls = self.env['product.pricelist'].search(
+            [('country_group_ids.country_ids.code', '=', self.country_id and self.country_id.code or False)],
+            limit=1
+        )
+        default_for_country = pls and pls[0]
+        actual = self.env['ir.property'].get('property_product_pricelist', 'res.partner', 'res.partner,%s' % self.id)
+
+        # update at each change country, and so erase old pricelist
+        if self.property_product_pricelist or (actual and default_for_country and default_for_country.id != actual.id):
+            # keep the company of the current user before sudo
+            self.env['ir.property'].sudo().set_multi(
+                'property_product_pricelist',
+                self._name,
+                {self.id: self.property_product_pricelist or default_for_country.id},
+                default_value=default_for_country.id
+            )


### PR DESCRIPTION
…rtner

Do : 
`self.env['ir.property'].sudo().set_multi(
                'property_product_pricelist',
                self._name,
                {self.id: self.property_product_pricelist or default_for_country.id},
                default_value=default_for_country.id
            ) `
Instead of : 
`self.env['ir.property'].with_context(force_company=self.env.user.company_id.id).sudo().set_multi(
                'property_product_pricelist',
                self._name,
                {self.id: self.property_product_pricelist or default_for_country.id},
                default_value=default_for_country.id
            )
`

Because context force_company is overwritten in inverse