### PR TITLE
[FIX] : #818665 Fix targeted form view when click on button LOG TIME

### DIFF
--- a/vcls-project/models/project_task.py
+++ b/vcls-project/models/project_task.py
@@ -81,13 +81,13 @@ class ProjectTask(models.Model):
         self.ensure_one()
         action = self.env.ref('hr_timesheet.act_hr_timesheet_line').read()[0]
         action['views'] = [
-          (self.env.ref('hr_timesheet.hr_timesheet_line_form').id, 'form'),
+          (self.env.ref('vcls-timesheet.account_analytic_line_grid_view_form').id, 'form'),
         ]
         ctx = self.env.context.copy()
         ctx.update(default_project_id=self.project_id.id,
                    default_task_id=self.id,
                    # One Employee/USer
-                   default_employee_id=self.env.user.employee_ids)
+                   default_employee_id=self.env.user.employee_ids.id)
         action.update({'context': ctx,
                        'target': 'new'})
         return action

--- a/vcls-timesheet/views/time_category_views.xml
+++ b/vcls-timesheet/views/time_category_views.xml
@@ -61,7 +61,6 @@
                     <field name="unit_amount" string="Hours Spent" required="1"/>
                 </field>
                 <xpath expr="//field[@name='employee_id']" position="after">
-                    <field name="task_id" invisible="1"/>
                     <field name="time_category_id" context="{'task_filter':True,'task_id':task_id}" option="{'no_create_edit': True}"/>
                 </xpath>
             </field>


### PR DESCRIPTION
Discussed with Mathieu in Teams. The right Form view is `vcls-timesheet.account_analytic_line_grid_view_form` and not `hr_timesheet.hr_timesheet_line_form`