### PR TITLE
005925_FIX_measure_date_crash_pc_follow_up

### DIFF
--- a/vcls-timesheet/models/project_timesheet_forecast_report.py
+++ b/vcls-timesheet/models/project_timesheet_forecast_report.py
@@ -30,7 +30,6 @@ class TimesheetForecastReport(models.Model):
         readonly=True
     )
 
-    date = fields.Float()
     employee_seniority_level_id = fields.Many2one(
         'hr.employee.seniority.level',
         String='Seniority Level', readonly=True


### PR DESCRIPTION
removing the field "date" from the measures dropdown menu in pivot view in PC project follow up