### PR TITLE
005940_ADD_historical_invoiced_amount

### DIFF
--- a/vcls-rdd/models/sale_order.py
+++ b/vcls-rdd/models/sale_order.py
@@ -198,6 +198,7 @@ class SaleOrderLine(models.Model):
                         elif invoice_line.invoice_id.type == 'out_refund':
                             qty_invoiced -= invoice_line.uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
             line.qty_invoiced = qty_invoiced
+        super()._get_invoice_qty()
 
     @api.multi
     @api.depends('qty_delivered_method', 'qty_delivered_manual', 'analytic_line_ids.so_line', 'analytic_line_ids.unit_amount', 'analytic_line_ids.product_uom_id')

--- a/vcls-timesheet/__manifest__.py
+++ b/vcls-timesheet/__manifest__.py
@@ -16,7 +16,7 @@
     # for the full list
     'category': 'Uncategorized',
 
-    'version': '0.3.13',
+    'version': '0.3.14',
 
 
     # any module necessary for this one to work correctly

--- a/vcls-timesheet/views/sale_order_views.xml
+++ b/vcls-timesheet/views/sale_order_views.xml
@@ -5,6 +5,9 @@
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="vcls-crm.view_order_form" />
             <field name="arch" type="xml">
+                <xpath expr="//tree//field[@name='discount']" position="after">
+                    <field name="historical_invoiced_amount"/>
+                </xpath>
                 <xpath expr="//div[@name='button_box']" position="inside">
                     <button type="action"
                             class="oe_stat_button"


### PR DESCRIPTION
Added a column "Historical Invoiced Amount" to the quotation view. It allows user to enter manually an already invoiced amount from a previous invoicing.

Historical_invoiced_amount added to "delivered from task" and "invoiced from task" if it's Time and Material.
Or Historical invoiced amount / unit_price  added to qty_delivered and qty_invoice.