### PR TITLE
005993_kpi

### DIFF
--- a/vcls-project/__manifest__.py
+++ b/vcls-project/__manifest__.py
@@ -15,7 +15,7 @@
     # Check https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Uncategorized',
-    'version': '0.8.9',
+    'version': '0.8.10',
 
     # any module necessary for this one to work correctly
     'depends': [

--- a/vcls-project/models/project.py
+++ b/vcls-project/models/project.py
@@ -56,7 +56,7 @@ class Project(models.Model):
     #consultant_ids = fields.Many2many('hr.employee', string='Consultants')
     #ta_ids = fields.Many2many('hr.employee', string='Ta')
     completion_ratio = fields.Float('Task Complete', compute='compute_project_completion_ratio', store=True)
-    consumed_value = fields.Float('Budget Consumed', compute='compute_project_consumed_value', store=True)
+    # consumed_value = fields.Float('Budget Consumed', compute='compute_project_consumed_value', store=True)
     consummed_completed_ratio = fields.Float('BC / TC',
                                              compute='compute_project_consummed_completed_ratio', store=True)
     summary_ids = fields.One2many(
@@ -449,14 +449,14 @@ class Project(models.Model):
             tasks = project.get_tasks_for_project_sub_project()
             project.completion_ratio = sum(tasks.mapped('completion_ratio')) / len(tasks) if tasks else sum(tasks.mapped('completion_ratio'))
 
-    @api.multi
-    @api.depends('task_ids.progress')
-    def compute_project_consumed_value(self):
-        for project in self:
-            tasks = project.get_tasks_for_project_sub_project()
-            #_logger.info("TASK FOUND {} with {}".format(tasks.mapped('name'),tasks.mapped('progress')))
-            project.consumed_value = sum(tasks.mapped('progress')) / len(tasks) if tasks \
-                else sum(tasks.mapped('progress'))
+    # @api.multi
+    # @api.depends('task_ids.progress')
+    # def compute_project_consumed_value(self):
+    #     for project in self:
+    #         tasks = project.get_tasks_for_project_sub_project()
+    #         #_logger.info("TASK FOUND {} with {}".format(tasks.mapped('name'),tasks.mapped('progress')))
+    #         project.consumed_value = sum(tasks.mapped('progress')) / len(tasks) if tasks \
+    #             else sum(tasks.mapped('progress'))
 
     @api.multi
     @api.depends('task_ids.consummed_completed_ratio')

--- a/vcls-project/models/project.py
+++ b/vcls-project/models/project.py
@@ -56,7 +56,6 @@ class Project(models.Model):
     #consultant_ids = fields.Many2many('hr.employee', string='Consultants')
     #ta_ids = fields.Many2many('hr.employee', string='Ta')
     completion_ratio = fields.Float('Task Complete', compute='compute_project_completion_ratio', store=True)
-    # consumed_value = fields.Float('Budget Consumed', compute='compute_project_consumed_value', store=True)
     consummed_completed_ratio = fields.Float('BC / TC',
                                              compute='compute_project_consummed_completed_ratio', store=True)
     summary_ids = fields.One2many(
@@ -448,15 +447,6 @@ class Project(models.Model):
         for project in self:
             tasks = project.get_tasks_for_project_sub_project()
             project.completion_ratio = sum(tasks.mapped('completion_ratio')) / len(tasks) if tasks else sum(tasks.mapped('completion_ratio'))
-
-    # @api.multi
-    # @api.depends('task_ids.progress')
-    # def compute_project_consumed_value(self):
-    #     for project in self:
-    #         tasks = project.get_tasks_for_project_sub_project()
-    #         #_logger.info("TASK FOUND {} with {}".format(tasks.mapped('name'),tasks.mapped('progress')))
-    #         project.consumed_value = sum(tasks.mapped('progress')) / len(tasks) if tasks \
-    #             else sum(tasks.mapped('progress'))
 
     @api.multi
     @api.depends('task_ids.consummed_completed_ratio')

--- a/vcls-project/models/project_summary.py
+++ b/vcls-project/models/project_summary.py
@@ -23,7 +23,6 @@ class ProjectSummary(models.Model):
         'External summary'
     )
     completion_ratio = fields.Float('Task Complete')
-    # consumed_value = fields.Float('Budget Consumed')
     consumed_completed_ratio = fields.Float('BC/TC')
 
     @api.multi

--- a/vcls-project/models/project_summary.py
+++ b/vcls-project/models/project_summary.py
@@ -23,7 +23,7 @@ class ProjectSummary(models.Model):
         'External summary'
     )
     completion_ratio = fields.Float('Task Complete')
-    consumed_value = fields.Float('Budget Consumed')
+    # consumed_value = fields.Float('Budget Consumed')
     consumed_completed_ratio = fields.Float('BC/TC')
 
     @api.multi

--- a/vcls-project/views/project_summary_views.xml
+++ b/vcls-project/views/project_summary_views.xml
@@ -12,7 +12,6 @@
                             </group>
                             <group colspan="6" col="6">
                                 <field name="completion_ratio" widget="percentpie" nolabel="1"/>
-                                <!-- <field name="consumed_value" widget="percentpie" nolabel="1"/> -->
                                 <field name="consumed_completed_ratio" widget="percentpie" nolabel="1"/>
                             </group>
                         <group>

--- a/vcls-project/views/project_summary_views.xml
+++ b/vcls-project/views/project_summary_views.xml
@@ -12,7 +12,7 @@
                             </group>
                             <group colspan="6" col="6">
                                 <field name="completion_ratio" widget="percentpie" nolabel="1"/>
-                                <field name="consumed_value" widget="percentpie" nolabel="1"/>
+                                <!-- <field name="consumed_value" widget="percentpie" nolabel="1"/> -->
                                 <field name="consumed_completed_ratio" widget="percentpie" nolabel="1"/>
                             </group>
                         <group>

--- a/vcls-project/views/project_views.xml
+++ b/vcls-project/views/project_views.xml
@@ -68,10 +68,8 @@
                             <field name="scope_of_work"/>
                         </group>
                         <group string="Project KPIs">
-                            <group>
+                            <group name="project_kpis">
                                 <field name="completion_ratio" widget="percentpie" nolabel="1"/>
-                                <!-- <br/>
-                                <field name="consumed_value" widget="percentpie" nolabel="1"/> -->
                             </group>
                             <group>
                                 <br/>
@@ -165,18 +163,11 @@
                                     'default_consumed_completed_ratio': consummed_completed_ratio,
                                 }"                                
                             />
-                                <!-- context="{
-                                    'default_project_id': active_id,
-                                    'default_completion_ratio': completion_ratio,
-                                    'default_consumed_value': consumed_value,
-                                    'default_consumed_completed_ratio': consummed_completed_ratio,
-                                }" -->
 
                             <field name="summary_ids" mode="kanban">
                                 <kanban create="0">
                                     <field name="completion_ratio"/>
                                     <field name="consumed_completed_ratio"/>
-                                    <!-- <field name="consumed_value"/> -->
                                     <field name="create_date"/>
                                     <templates>
                                         <t t-name="kanban-box">
@@ -187,9 +178,6 @@
                                                     </strong>
                                                     <div>
                                                         <field name="completion_ratio" widget="percentage" nolabel="0"/>
-                                                    </div>
-                                                    <div>
-                                                        <!-- <field name="consumed_value" widget="percentage" nolabel="0"/> -->
                                                     </div>
                                                     <div>
                                                         <field name="consumed_completed_ratio" string= "BC / TC" widget="percentage"
@@ -389,7 +377,6 @@
                         <field name="partner_id" string="Client"/>
                         <field name="task_ids"/>
                         <field name="completion_ratio" string="Task Complete"/>
-                        <!-- <field name="consumed_value" string="Budget Consumed"/> -->
                         <field name="consummed_completed_ratio" string="BC/TC"/>
                     </tree>
                 </field>

--- a/vcls-project/views/project_views.xml
+++ b/vcls-project/views/project_views.xml
@@ -70,8 +70,8 @@
                         <group string="Project KPIs">
                             <group>
                                 <field name="completion_ratio" widget="percentpie" nolabel="1"/>
-                                <br/>
-                                <field name="consumed_value" widget="percentpie" nolabel="1"/>
+                                <!-- <br/>
+                                <field name="consumed_value" widget="percentpie" nolabel="1"/> -->
                             </group>
                             <group>
                                 <br/>
@@ -162,17 +162,21 @@
                                 context="{
                                     'default_project_id': active_id,
                                     'default_completion_ratio': completion_ratio,
+                                    'default_consumed_completed_ratio': consummed_completed_ratio,
+                                }"                                
+                            />
+                                <!-- context="{
+                                    'default_project_id': active_id,
+                                    'default_completion_ratio': completion_ratio,
                                     'default_consumed_value': consumed_value,
                                     'default_consumed_completed_ratio': consummed_completed_ratio,
-                                }"
-                            />
-                            
+                                }" -->
 
                             <field name="summary_ids" mode="kanban">
                                 <kanban create="0">
                                     <field name="completion_ratio"/>
                                     <field name="consumed_completed_ratio"/>
-                                    <field name="consumed_value"/>
+                                    <!-- <field name="consumed_value"/> -->
                                     <field name="create_date"/>
                                     <templates>
                                         <t t-name="kanban-box">
@@ -185,7 +189,7 @@
                                                         <field name="completion_ratio" widget="percentage" nolabel="0"/>
                                                     </div>
                                                     <div>
-                                                        <field name="consumed_value" widget="percentage" nolabel="0"/>
+                                                        <!-- <field name="consumed_value" widget="percentage" nolabel="0"/> -->
                                                     </div>
                                                     <div>
                                                         <field name="consumed_completed_ratio" string= "BC / TC" widget="percentage"
@@ -385,7 +389,7 @@
                         <field name="partner_id" string="Client"/>
                         <field name="task_ids"/>
                         <field name="completion_ratio" string="Task Complete"/>
-                        <field name="consumed_value" string="Budget Consumed"/>
+                        <!-- <field name="consumed_value" string="Budget Consumed"/> -->
                         <field name="consummed_completed_ratio" string="BC/TC"/>
                     </tree>
                 </field>

--- a/vcls-timesheet/__manifest__.py
+++ b/vcls-timesheet/__manifest__.py
@@ -16,7 +16,7 @@
     # for the full list
     'category': 'Uncategorized',
 
-    'version': '0.3.26',
+    'version': '0.3.27',
 
 
     # any module necessary for this one to work correctly

--- a/vcls-timesheet/models/project.py
+++ b/vcls-timesheet/models/project.py
@@ -25,6 +25,18 @@ class Project(models.Model):
     pc_hours = fields.Float(string="PC Review Hours",readonly=True)
     cf_hours = fields.Float(string="Carry Forward Hours",readonly=True)
 
+    budget_consumed = fields.Float(
+        string="Budget Consumed new",
+        readonly=True,
+        compute='compute_budget_consumed',
+        )
+
+    @api.multi
+    @api.depends("realized_budget", "contractual_budget")
+    def compute_budget_consumed(self):
+        for project in self:
+            self.budget_consumed = project.realized_budget / project.contractual_budget
+
     @api.multi
     def _get_kpi(self):
         for project in self:

--- a/vcls-timesheet/models/project.py
+++ b/vcls-timesheet/models/project.py
@@ -29,13 +29,16 @@ class Project(models.Model):
         string="Budget Consumed new",
         readonly=True,
         compute='compute_budget_consumed',
-        )
+    )
 
     @api.multi
     @api.depends("realized_budget", "contractual_budget")
     def compute_budget_consumed(self):
         for project in self:
-            self.budget_consumed = project.realized_budget / project.contractual_budget
+            if project.contractual_budget:
+                self.budget_consumed = project.realized_budget / project.contractual_budget
+            else:
+                self.budget_consumed = False
 
     @api.multi
     def _get_kpi(self):

--- a/vcls-timesheet/models/project_task.py
+++ b/vcls-timesheet/models/project_task.py
@@ -117,13 +117,8 @@ class ProjectTask(models.Model):
     @api.multi
     def _get_kpi(self):
         for task in self.filtered(lambda s: not s.parent_id):
-            # analyzed_timesheet(account.analytic.line , is_timesheet= True)
-            # reporting_task_id(champ du timesheet) => pour chaque tache timesheet a prendre en compte. Valeur de la tache sur laquelle le reporting va etre effectué
-            
             analyzed_timesheet = task.project_id.timesheet_ids.filtered(lambda t: t.reporting_task_id == task)
-            # task.project_id.timesheet_ids.filtered(lambda t: t.reporting_task_id == task.id)
-            # ça va donner un pool de task a traiter ensuite comme avant ou quasiment en remplacant dans le sum: task. par analyzed_timesheet. 
-        
+
             task.contractual_budget = task.sale_line_id.price_unit * task.sale_line_id.product_uom_qty
             task.forecasted_budget = sum([
                 hourly_rate * resource_hours for hourly_rate, resource_hours in

--- a/vcls-timesheet/models/project_task.py
+++ b/vcls-timesheet/models/project_task.py
@@ -50,6 +50,24 @@ class ProjectTask(models.Model):
     pc_hours = fields.Float(string="PC Review Hours",readonly=True)
     cf_hours = fields.Float(string="Carry Forward Hours",readonly=True)
 
+    allow_budget_modification = fields.Boolean(default="False")
+    recompute_kpi = fields.Boolean(default="False")
+
+    budget_consumed = fields.Float(
+        string="Budget Consumed new",
+        readonly=True,
+        compute='compute_budget_consumed',
+        )
+
+    @api.multi
+    @api.depends("realized_budget", "contractual_budget")
+    def compute_budget_consumed(self):
+        for project in self:
+            if project.contractual_budget:
+                self.budget_consumed = project.realized_budget / project.contractual_budget
+            else:
+                self.budget_consumed = False
+
     @api.depends('date_end')
     def _compute_deadline(self):
         for task in self:
@@ -84,54 +102,94 @@ class ProjectTask(models.Model):
         projects._get_kpi()
         # self._cr.execute('update project_task set ')
 
+    @api.onchange('allow_budget_modification', 'recompute_kpi')
+    def onchange_allow_budget_modification_get_kpi(self):
+        self._get_kpi()
+        project = self.project_id
+        project._get_kpi()
+
+    @api.multi
+    def button_get_kpi(self):
+        self._get_kpi()
+        project = self.project_id
+        project._get_kpi()
+
     @api.multi
     def _get_kpi(self):
-        for task in self:
+        for task in self.filtered(lambda s: not s.parent_id):
+            # analyzed_timesheet(account.analytic.line , is_timesheet= True)
+            # reporting_task_id(champ du timesheet) => pour chaque tache timesheet a prendre en compte. Valeur de la tache sur laquelle le reporting va etre effectué
+            
+            analyzed_timesheet = task.project_id.timesheet_ids.filtered(lambda t: t.reporting_task_id == task)
+            # task.project_id.timesheet_ids.filtered(lambda t: t.reporting_task_id == task.id)
+            # ça va donner un pool de task a traiter ensuite comme avant ou quasiment en remplacant dans le sum: task. par analyzed_timesheet. 
+        
             task.contractual_budget = task.sale_line_id.price_unit * task.sale_line_id.product_uom_qty
             task.forecasted_budget = sum([
                 hourly_rate * resource_hours for hourly_rate, resource_hours in
                 zip(task.forecast_ids.mapped('hourly_rate'), task.forecast_ids.mapped('resource_hours'))
             ])
             task.realized_budget = sum(
-                task.timesheet_ids.filtered(lambda t: t.stage_id not in ('draft', 'outofscope'))
+                analyzed_timesheet.filtered(lambda t: t.stage_id not in ('draft', 'outofscope'))
                     .mapped(lambda t:t.unit_amount * t.so_line_unit_price)
             )
             task.valued_budget = sum(
-                task.timesheet_ids.filtered(lambda t: t.stage_id not in ('draft', 'outofscope'))
+                analyzed_timesheet.filtered(lambda t: t.stage_id not in ('draft', 'outofscope'))
                     .mapped(lambda t:t.unit_amount_rounded * t.so_line_unit_price)
             )
             task.pc_budget = sum(
-                task.timesheet_ids.filtered(lambda t: t.stage_id in ('pc_review'))
+                analyzed_timesheet.filtered(lambda t: t.stage_id in ('pc_review'))
                     .mapped(lambda t:t.unit_amount_rounded * t.so_line_unit_price)
             )
             task.cf_budget = sum(
-                task.timesheet_ids.filtered(lambda t: t.stage_id in ('carry_forward'))
+                analyzed_timesheet.filtered(lambda t: t.stage_id in ('carry_forward'))
                     .mapped(lambda t:t.unit_amount_rounded * t.so_line_unit_price)
             )
             task.invoiced_budget = sum(
-                task.timesheet_ids.filtered(lambda t: t.stage_id == 'invoiced')
+                analyzed_timesheet.filtered(lambda t: t.stage_id == 'invoiced')
                     .mapped(lambda t:t.unit_amount_rounded * t.so_line_unit_price)
             )
             task.forecasted_hours = sum(task.forecast_ids.mapped('resource_hours'))
-            task.realized_hours = sum(task.timesheet_ids.filtered(
+            task.realized_hours = sum(analyzed_timesheet.filtered(
                 lambda t: t.stage_id not in ('draft', 'outofscope')
             ).mapped('unit_amount'))
-            task.valued_hours = sum(task.timesheet_ids.filtered(
+            task.valued_hours = sum(analyzed_timesheet.filtered(
                 lambda t: t.stage_id not in ('draft', 'outofscope')
             ).mapped('unit_amount_rounded'))
-            task.pc_hours = sum(task.timesheet_ids.filtered(
+            task.pc_hours = sum(analyzed_timesheet.filtered(
                 lambda t: t.stage_id in ('pc_review')
             ).mapped('unit_amount_rounded'))
-            task.cf_hours = sum(task.timesheet_ids.filtered(
+            task.cf_hours = sum(analyzed_timesheet.filtered(
                 lambda t: t.stage_id in ('carry_forward')
             ).mapped('unit_amount_rounded'))
-            task.invoiced_hours = sum(task.timesheet_ids.filtered(
+    
+            task.invoiced_hours = sum(analyzed_timesheet.filtered(
                 lambda t: t.stage_id == 'invoiced'
             ).mapped('unit_amount_rounded'))
-
             task.valuation_ratio = 100.0*(task.valued_hours / task.realized_hours) if task.realized_hours else False
 
-            #task.sale_line_id._compute_untaxed_amount_to_invoice()
+            if task.allow_budget_modification is False:
+                task.contractual_budget = False
+                task.forecasted_budget = False
+                task.realized_budget = False
+                task.valued_budget = False
+                task.invoiced_budget = False
+                task.pc_budget = False
+                task.cf_budget = False
+                # task.forecasted_hours = False
+                # task.realized_hours = False
+                # task.valued_hours = False
+                # task.pc_hours = False
+                # task.cf_hours = False
+                # task.invoiced_hours = False
+                # task.valuation_ratio = False
+
+    @api.onchange('parent_id')
+    def onchange_allow_budget_modification(self):
+        if self.parent_id.id is not False:
+            self.allow_budget_modification = False
+        else:
+            self.allow_budget_modification = True
 
     @api.onchange('sale_line_id')
     def _onchange_lead_id(self):
@@ -189,6 +247,11 @@ class ProjectTask(models.Model):
             date_end = task.sale_line_id.order_id.expected_end_date
             if date_end:
                 task.date_end = datetime.fromordinal(date_end.toordinal())
+
+        if task.parent_id.id is not False:
+            task.allow_budget_modification = False
+        else:
+            task.allow_budget_modification = True
         return task
 
     @api.one

--- a/vcls-timesheet/views/projects_views.xml
+++ b/vcls-timesheet/views/projects_views.xml
@@ -65,19 +65,28 @@
                         }"
                     />
                 </button>
+                <xpath expr="//field[@name='progress']" position="replace">
+                    <field name="budget_consumed" widget="progressbar" string="Budget Consumed"/>
+                </xpath>
 
                 <field name="consummed_completed_ratio" position="after">
                     <br/>
                     <field name="valuation_ratio" widget="percentpie" nolabel="1"/>
+                    <!-- TEST TODO remove it -->
+                    <button type="object" class = 'btn btn-primary' name="button_get_kpi" string="Refresh KPI"/>
                 </field>
 
                 <field name="parent_id" position="attributes">
                     <attribute name="domain">[('project_id','=',project_id),('parent_id','=',False)]</attribute>
                 </field>
-                
+                <xpath expr="//page//field[@name='progress']" position="replace">
+                    <field name="progress" string="Consumed Hours" widget="progressbar"/>
+                </xpath>
                 <xpath expr="//page[last()]" position="after">
-                    <page string="KPI" name="kpi">
+                    <!-- HERE FOLOOWING IS THE GOOD LINE -->
+                    <page string="KPI" name="kpi" attrs="{'invisible': [('allow_budget_modification', '!=', True)]}">
                     <group>
+                    <field name="allow_budget_modification" invisible="1"/>
                         <group string="Hours">
                             <field name="forecasted_hours"/>
                             <field name="realized_hours"/>
@@ -159,7 +168,7 @@
                     <field name="risk_score"/>
                     <field name="risk_ids"  widget="many2many_tags"/>
                     <field name="completion_ratio"/>
-                    <field name="consumed_value" widget="integer"/>
+                    <!-- <field name="consumed_value" widget="integer"/> -->
                     <field name="consummed_completed_ratio" widget="integer"/>
                     <field name="valuation_ratio"/>
                     <field name="invoicing_mode"/>

--- a/vcls-timesheet/views/projects_views.xml
+++ b/vcls-timesheet/views/projects_views.xml
@@ -72,8 +72,6 @@
                 <field name="consummed_completed_ratio" position="after">
                     <br/>
                     <field name="valuation_ratio" widget="percentpie" nolabel="1"/>
-                    <!-- TEST TODO remove it -->
-                    <button type="object" class = 'btn btn-primary' name="button_get_kpi" string="Refresh KPI"/>
                 </field>
 
                 <field name="parent_id" position="attributes">
@@ -100,8 +98,9 @@
                             <field name="realized_budget"/>
                             <field name="valued_budget"/>
                             <field name="invoiced_budget"/>
-                            <field name="pc_budget"/>
-                            <field name="cf_budget"/>
+                            <field name="invoicing_mode" invisible="1"/>
+                            <field name="pc_budget" attrs="{'invisible': [('invoicing_mode', '=', 'fixed_price')]}"/>
+                            <field name="cf_budget" attrs="{'invisible': [('invoicing_mode', '=', 'fixed_price')]}"/>
                         </group>
                     </group>
                     </page>
@@ -140,8 +139,9 @@
                                 <field name="realized_budget"/>
                                 <field name="valued_budget"/>
                                 <field name="invoiced_budget"/>
-                                <field name="pc_budget"/>
-                                <field name="cf_budget"/>
+                                <field name="invoicing_mode" invisible="1"/>
+                                <field name="pc_budget" attrs="{'invisible': [('invoicing_mode', '=', 'fixed_price')]}"/>
+                                <field name="cf_budget" attrs="{'invisible': [('invoicing_mode', '=', 'fixed_price')]}"/>
                             </group>
                             </group>
                         </page>

--- a/vcls-timesheet/views/projects_views.xml
+++ b/vcls-timesheet/views/projects_views.xml
@@ -83,7 +83,6 @@
                     <field name="progress" string="Consumed Hours" widget="progressbar"/>
                 </xpath>
                 <xpath expr="//page[last()]" position="after">
-                    <!-- HERE FOLOOWING IS THE GOOD LINE -->
                     <page string="KPI" name="kpi" attrs="{'invisible': [('allow_budget_modification', '!=', True)]}">
                     <group>
                     <field name="allow_budget_modification" invisible="1"/>
@@ -147,6 +146,10 @@
                             </group>
                         </page>
                     </page>
+                    <xpath expr="//group[@name='project_kpis']" position="inside">
+                        <br/>
+                        <field name="budget_consumed" widget="percentpie" nolabel="1"/>
+                    </xpath>
                     <field name="consummed_completed_ratio" position="after">
                         <br/>
                         <field name="valuation_ratio" widget="percentpie" nolabel="1"/>
@@ -168,7 +171,6 @@
                     <field name="risk_score"/>
                     <field name="risk_ids"  widget="many2many_tags"/>
                     <field name="completion_ratio"/>
-                    <!-- <field name="consumed_value" widget="integer"/> -->
                     <field name="consummed_completed_ratio" widget="integer"/>
                     <field name="valuation_ratio"/>
                     <field name="invoicing_mode"/>

--- a/vcls_marketing/__manifest__.py
+++ b/vcls_marketing/__manifest__.py
@@ -11,7 +11,7 @@
     'website': "http://www.voisinconsulting.com",
     'category': 'Uncategorized',
 
-    'version': '0.1.8',
+    'version': '0.1.9',
   
     'depends': [
         'crm',

--- a/vcls_marketing/views/marketing_views.xml
+++ b/vcls_marketing/views/marketing_views.xml
@@ -183,7 +183,7 @@
                                         </div>
                                 </group>
                                 <group>
-                                    <field name="progress" widget="progressbar"/>
+                                    <field name="progress" widget="progressbar" string="Consumed Hours"/>
                                 </group>
                             </group>
                             <group name="timesheet_error" attrs="{'invisible': [('analytic_account_active', '!=', False)]}">


### PR DESCRIPTION
the subtask doesn't get involve in kpi anymore, the parent task get the reporting for them. new boolean field to enable or disable the budget calculation on the task. Separation of invoiced_mode T&M and other, if not T&M: hiding  PC Review Budget and Carry Forward Budget , and changing calculation for Realized Budget and Invoiced Budget. In the timesheet tab "progress" is renamed "Consumed hours" to be more explicit. in the project view Budget Consumed is based on realized budget  (not on timesheet anymore