### PR TITLE
FIX_006924_signature_email_from_odoo

### DIFF
--- a/vcls-theme/__manifest__.py
+++ b/vcls-theme/__manifest__.py
@@ -15,7 +15,7 @@
     # Check https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Uncategorized',
-    'version': '0.7.16',
+    'version': '0.7.17',
 
     # any module necessary for this one to work correctly
     'depends': [

--- a/vcls-theme/data/email_template.xml
+++ b/vcls-theme/data/email_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="message_notification_email_vcls" name="Message Email Notification" inherit_id="mail.message_notification_email">
+    <!-- <template id="message_notification_email_vcls" name="Message Email Notification" inherit_id="mail.message_notification_email">
         <xpath expr="//div" position="replace">
             <div>
                 <div t-raw="message.body"/>
@@ -12,5 +12,5 @@
             <div t-if="signature" t-raw="signature" style="font-size: 13px;"/>
         </div>
         </xpath>
-    </template>
+    </template> -->
 </odoo>


### PR DESCRIPTION
it was debranding all the "send email", not convenient for every one not used by the marketing yet, so back up until decision taken