### PR TITLE
007134_activity_report_task_order

### DIFF
--- a/vcls-invoicing/__manifest__.py
+++ b/vcls-invoicing/__manifest__.py
@@ -15,7 +15,7 @@
     # Check https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Uncategorized',
-    'version': '1.7.46',
+    'version': '1.7.47',
 
     # any module necessary for this one to work correctly
     'depends': [

--- a/vcls-invoicing/models/invoice.py
+++ b/vcls-invoicing/models/invoice.py
@@ -243,8 +243,12 @@ class Invoice(models.Model):
                         time_category_rate_matrix_data[time_category_matrix_key] += unit_amount
                         time_category_row_data.setdefault(time_category_id, None)
 
-        # reorder rate_product_ids columns according to the most expensive one
-        rate_product_ids = rate_product_ids
+        # reorder projects_row_data columns according to the sale.order.line sequence to  mimic the sale order
+        # structure looks like: OrderedDict([(project.project(146,), OrderedDict([(project.task(945,), [...]), (project.task(946,), [...]), (project.task(943,), [...])]))])
+        if projects_row_data and projects_row_data[project_id]:
+            projects_row_data[project_id] = OrderedDict(sorted(list(list(projects_row_data.items())[0][1].items()), key= lambda x : x[0][0].sale_line_id.sequence))
+
+        # reorder rate_product_ids columns according to the most hours coded one
         rate_product_ids = product_obj.browse(OrderedSet([
             couple[1].id for couple in
             sorted(

--- a/vcls-invoicing/reports/activity_reports.xml
+++ b/vcls-invoicing/reports/activity_reports.xml
@@ -50,6 +50,7 @@
                     <th>Grand Total</th>
                 </thead>
                 <tbody>
+                    <!-- iteration of each project  + the rates + the total of hour for each rate -->
                     <t t-foreach="list(projects_row_data)" t-as="project_id">
                         <t t-set="tasks_row_data" t-value="projects_row_data[project_id]"/>
                         <tr style="font-weight: bold;">
@@ -61,6 +62,7 @@
                                 <t t-esc="sum([project_rate_matrix_data.get((project_id, rate_product_id), 0) for rate_product_id in rate_product_ids])"/>
                             </td>
                         </tr>
+                        <!-- iteration on the task/subtask -->
                         <t t-set="prev_ancestor_id" t-value=""/>
                         <t t-foreach="list(tasks_row_data)" t-as="task_id">
                             <t t-set="time_category_row_data" t-value="tasks_row_data[task_id][0]"/>
@@ -70,6 +72,7 @@
                                 <t t-set="nb_tasks" t-value="tasks_row_data[task_id][2]"/>
                                 <t t-set="merge_subtask" t-value="tasks_row_data[task_id][3]"/>
 
+                                <!-- condition to make the parent task appear or not every loop -->
                                 <t t-if="prev_ancestor_id != ancestor_id and nb_tasks > 1 and not merge_subtask">
                                 <tr>
                                     <td class="pl-3" style="font-weight: bold;"><t t-esc="ancestor_id.name"/></td>
@@ -90,9 +93,11 @@
                                 </t>
                                 <t t-set="prev_ancestor_id" t-value="ancestor_id"/>
 
+                                <!-- iteration for the rate of each time category -->
                                 <td t-foreach="rate_product_ids" t-as="rate_product_id" class="text-right">
                                     <t t-esc="task_rate_matrix_data.get((project_id, task_id, rate_product_id), ['-', '-'])[0]"/>
                                 </td>
+                                <!-- total of the line under "Grand Total" -->
                                 <td class="text-right">
                                     <t t-esc="sum([task_rate_matrix_data.get((project_id, task_id, rate_product_id), [0, 0])[0] for rate_product_id in rate_product_ids])"/>
                                 </td>


### PR DESCRIPTION
Reordering the task to follow the sale order , to make it more readable. The complexe date structure make it hard to follow.  the structure looks like: OrderedDict([(project.project(146,), OrderedDict([(project.task(945,), [...]), (project.task(946,), [...]), (project.task(943,), [...])]))])
