### PR TITLE
007071_quotation_name_editable

### DIFF
--- a/vcls-crm/__manifest__.py
+++ b/vcls-crm/__manifest__.py
@@ -14,7 +14,7 @@
     'category': 'Uncategorized',
 
 
-    'version': '1.3.7',
+    'version': '1.3.8',
 
 
     # any module necessary for this one to work correctly

--- a/vcls-crm/models/sale_order.py
+++ b/vcls-crm/models/sale_order.py
@@ -103,8 +103,7 @@ class SaleOrder(models.Model):
     name = fields.Char(
         string='Order Reference',
         required=True, copy=False,
-        readonly=True,
-        states={'draft': [('readonly', False)]},
+        readonly=False,
         index=True, default=lambda self: 'New'
     )
     family_order_count = fields.Integer(

--- a/vcls-crm/views/sale_order_views.xml
+++ b/vcls-crm/views/sale_order_views.xml
@@ -277,9 +277,26 @@
                 <xpath expr="//button[@name='action_view_invoice']" position="attributes">
                     <attribute name="invisible">0</attribute>
                 </xpath>
+                <xpath expr="//div[@class='oe_title']" position="replace">
+                    <h1>
+                        <field name="name" attrs="{'readonly':[('state', '!=', 'draft')]}" />
+                    </h1>
+                </xpath>
             </field>
         </record>
 
-
+        <record id="view_order_form_editable_quotation_name_group" model="ir.ui.view">
+            <field name="name">sale.order.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="groups_id" eval="[(4,ref('vcls-hr.vcls_group_superuser_lvl1')),(4,ref('vcls_security.group_bd_admin')), (4,ref('vcls_security.vcls_account_manager')), (4,ref('vcls-hr.vcls_group_superuser_lvl2'))]"/>
+            <field name="arch" type="xml">
+                <field name="name" position="replace">
+                    <h1>
+                        <field name="name" readonly="False"/>
+                    </h1>
+                </field>
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
make the quotation title editable for BD and AM, event after the state quotation sent - sale order. For the rest of the user (LC , consultant...), we keep the old usage, no possibility to change the quotation name after "draft" stage